### PR TITLE
Replace obsolete `lazy_static` dependency with `std::sync::LazyLock`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ include = ["/src/**/*", "/examples/**/*", "/tests/**/*", "/Cargo.toml", "/README
 edition = "2021"
 
 [dependencies]
-lazy_static = "1"
 log = "0.4"
 regex = "1"
 serde = { version = "1", optional = true, features = ["derive"] }


### PR DESCRIPTION
`LazyLock` has been available since Rust v1.80 and is a built-in stable replacement for the popular `lazy_static` crate.

see https://doc.rust-lang.org/std/sync/struct.LazyLock.html