### PR TITLE
Cargo.toml: Remove deprecated fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openair"
 version = "0.3.2"
-authors = ["Danilo Bargen <mail@dbrgn.ch>"]
 description = "Parser for airspace files in OpenAir format."
 keywords = ["airspace", "skytraxx", "variometer", "openair", "parser"]
 categories = ["parser-implementations"]
@@ -11,10 +10,6 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 include = ["/src/**/*", "/examples/**/*", "/tests/**/*", "/Cargo.toml", "/README.md", "/LICENSE-*"]
 edition = "2021"
-
-[badges]
-circle-ci = { repository = "dbrgn/openair-rs" }
-maintenance = { status = "actively-developed" }
 
 [dependencies]
 lazy_static = "1"


### PR DESCRIPTION
These fields are no longer processed by crates.io and cargo, so we may as well remove them :)