### PR TITLE
Make `Airspace::name` optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! use openair::{Airspace, Altitude, Class, Coord, Geometry};
 //!
 //! let airspace = Airspace {
-//!     name: "Example Zone".to_string(),
+//!     name: Some("Example Zone".to_string()),
 //!     class: Class::D,
 //!     type_: None,
 //!     lower_bound: Altitude::Gnd,
@@ -91,7 +91,7 @@ pub use crate::{
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Airspace {
     /// The name / description of the airspace
-    pub name: String,
+    pub name: Option<String>,
     /// The airspace class
     pub class: Class,
     /// The airspace type (extension record)
@@ -124,7 +124,11 @@ impl fmt::Display for Airspace {
         write!(
             f,
             "{} [{}] ({} → {}) {{{}}}",
-            self.name, self.class, self.lower_bound, self.upper_bound, self.geom,
+            self.name.as_deref().unwrap_or(""),
+            self.class,
+            self.lower_bound,
+            self.upper_bound,
+            self.geom,
         )
     }
 }
@@ -140,8 +144,10 @@ impl Airspace {
             Record::AirspaceType(type_).write(&mut writer)?;
         }
 
-        // 3. AN (name) - required
-        Record::AirspaceName(&self.name).write(&mut writer)?;
+        // 3. AN (name) - optional
+        if let Some(ref name) = self.name {
+            Record::AirspaceName(name).write(&mut writer)?;
+        }
 
         // 4. AL (lower bound) - required
         Record::LowerBound(self.lower_bound.clone()).write(&mut writer)?;
@@ -279,12 +285,12 @@ impl<R: BufRead> OpenAirIterator<R> {
                 // However, if we have accumulated an airspace, we should return it first
                 if let Some(class) = class {
                     debug!("Finish {:?}", name);
-                    let name = name.ok_or("Missing name")?;
+                    let label = name.as_deref().unwrap_or("<unnamed>");
                     let lower_bound =
-                        lower_bound.ok_or_else(|| format!("Missing lower bound for '{name}'"))?;
+                        lower_bound.ok_or_else(|| format!("Missing lower bound for '{label}'"))?;
                     let upper_bound =
-                        upper_bound.ok_or_else(|| format!("Missing upper bound for '{name}'"))?;
-                    let geom = geom.ok_or_else(|| format!("Missing geom for '{name}'"))?;
+                        upper_bound.ok_or_else(|| format!("Missing upper bound for '{label}'"))?;
+                    let geom = geom.ok_or_else(|| format!("Missing geom for '{label}'"))?;
                     return Ok(Some(Airspace {
                         name,
                         class,
@@ -317,12 +323,12 @@ impl<R: BufRead> OpenAirIterator<R> {
 
                 // Build and return airspace from accumulated data
                 debug!("Finish {:?}", name);
-                let name = name.ok_or("Missing name")?;
+                let label = name.as_deref().unwrap_or("<unnamed>");
                 let lower_bound =
-                    lower_bound.ok_or_else(|| format!("Missing lower bound for '{name}'"))?;
+                    lower_bound.ok_or_else(|| format!("Missing lower bound for '{label}'"))?;
                 let upper_bound =
-                    upper_bound.ok_or_else(|| format!("Missing upper bound for '{name}'"))?;
-                let geom = geom.ok_or_else(|| format!("Missing geom for '{name}'"))?;
+                    upper_bound.ok_or_else(|| format!("Missing upper bound for '{label}'"))?;
+                let geom = geom.ok_or_else(|| format!("Missing geom for '{label}'"))?;
                 // We already checked that class.is_some() in should_yield condition
                 let class = class.unwrap();
                 return Ok(Some(Airspace {
@@ -538,9 +544,39 @@ mod tests {
     }
 
     #[test]
+    fn write_without_name() {
+        let airspace = Airspace {
+            name: None,
+            class: Class::D,
+            type_: None,
+            lower_bound: Altitude::Gnd,
+            upper_bound: Altitude::FlightLevel(100),
+            geom: Geometry::Circle {
+                centerpoint: Coord {
+                    lat: 47.0,
+                    lng: 8.0,
+                },
+                radius: 5.0,
+            },
+            frequency: None,
+            call_sign: None,
+            transponder_code: None,
+            activation_times: None,
+        };
+
+        insta::assert_snapshot!(write_airspace(&airspace), @r"
+        AC D
+        AL GND
+        AH FL100
+        V X=47:00:00 N 008:00:00 E
+        DC 5
+        ");
+    }
+
+    #[test]
     fn write_minimal_circle() {
         let airspace = Airspace {
-            name: "Test Zone".to_string(),
+            name: Some("Test Zone".to_string()),
             class: Class::D,
             type_: None,
             lower_bound: Altitude::Gnd,
@@ -571,7 +607,7 @@ mod tests {
     #[test]
     fn write_full_circle() {
         let airspace = Airspace {
-            name: "Full Test Zone".to_string(),
+            name: Some("Full Test Zone".to_string()),
             class: Class::Ctr,
             type_: Some("CTR".to_string()),
             lower_bound: Altitude::FeetAmsl(1000),
@@ -607,7 +643,7 @@ mod tests {
     #[test]
     fn write_polygon_with_points() {
         let airspace = Airspace {
-            name: "Polygon Zone".to_string(),
+            name: Some("Polygon Zone".to_string()),
             class: Class::A,
             type_: None,
             lower_bound: Altitude::Gnd,
@@ -648,7 +684,7 @@ mod tests {
     #[test]
     fn write_polygon_with_arc_segment() {
         let airspace = Airspace {
-            name: "Arc Segment Zone".to_string(),
+            name: Some("Arc Segment Zone".to_string()),
             class: Class::Restricted,
             type_: None,
             lower_bound: Altitude::FeetAgl(0),
@@ -692,7 +728,7 @@ mod tests {
     #[test]
     fn write_polygon_with_arc() {
         let airspace = Airspace {
-            name: "Arc Zone".to_string(),
+            name: Some("Arc Zone".to_string()),
             class: Class::Danger,
             type_: None,
             lower_bound: Altitude::Gnd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@ pub use crate::{
     geometry::{Arc, ArcSegment, Direction, Geometry, PolygonSegment},
 };
 
+const FALLBACK_NAME: &str = "<unnamed>";
+
 /// An airspace.
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
@@ -124,7 +126,7 @@ impl fmt::Display for Airspace {
         write!(
             f,
             "{} [{}] ({} → {}) {{{}}}",
-            self.name.as_deref().unwrap_or(""),
+            self.name.as_deref().unwrap_or(FALLBACK_NAME),
             self.class,
             self.lower_bound,
             self.upper_bound,
@@ -285,7 +287,7 @@ impl<R: BufRead> OpenAirIterator<R> {
                 // However, if we have accumulated an airspace, we should return it first
                 if let Some(class) = class {
                     debug!("Finish {:?}", name);
-                    let label = name.as_deref().unwrap_or("<unnamed>");
+                    let label = name.as_deref().unwrap_or(FALLBACK_NAME);
                     let lower_bound =
                         lower_bound.ok_or_else(|| format!("Missing lower bound for '{label}'"))?;
                     let upper_bound =
@@ -323,7 +325,7 @@ impl<R: BufRead> OpenAirIterator<R> {
 
                 // Build and return airspace from accumulated data
                 debug!("Finish {:?}", name);
-                let label = name.as_deref().unwrap_or("<unnamed>");
+                let label = name.as_deref().unwrap_or(FALLBACK_NAME);
                 let lower_bound =
                     lower_bound.ok_or_else(|| format!("Missing lower bound for '{label}'"))?;
                 let upper_bound =

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -72,7 +72,7 @@ fn flyland_buochs() {
     let mut spaces = parse(&mut airspace).collect::<Result<Vec<_>, _>>().unwrap();
     assert_eq!(spaces.len(), 1);
     let space: Airspace = spaces.pop().unwrap();
-    assert_eq!(space.name, "BUOCHS Be CTR 119.625");
+    assert_eq!(space.name.as_deref(), Some("BUOCHS Be CTR 119.625"));
     assert_eq!(space.lower_bound, Altitude::Gnd);
     assert_eq!(space.upper_bound, Altitude::FeetAmsl(12959));
     if let Geometry::Polygon { segments } = space.geom {
@@ -185,6 +185,29 @@ fn extension_records() {
     assert_eq!(airspace.transponder_code, Some(1234));
 }
 
+/// AN is optional per the OpenAir spec. Airspaces without AN should parse
+/// successfully with `name` set to `None`.
+#[test]
+fn missing_name() {
+    let mut airspace = indoc! {"
+        AC D
+        AL GND
+        AH 5000 ft
+        DP 50:00:00 N 010:00:00 E
+        DP 50:00:00 N 010:01:00 E
+        DP 50:01:00 N 010:01:00 E
+        DP 50:01:00 N 010:00:00 E
+    "}
+    .as_bytes();
+    let spaces = parse(&mut airspace).collect::<Result<Vec<_>, _>>().unwrap();
+    assert_eq!(spaces.len(), 1);
+    let space = &spaces[0];
+    assert_eq!(space.name, None);
+    assert_eq!(space.class, Class::D);
+    assert_eq!(space.lower_bound, Altitude::Gnd);
+    assert_eq!(space.upper_bound, Altitude::FeetAmsl(5000));
+}
+
 /// Test that AN (Airspace Name) can act as a separator when it appears before AC.
 /// Some files use AN before AC, making AN the delimiter between airspaces.
 #[test]
@@ -225,14 +248,14 @@ fn an_record_as_separator() {
 
     // Check first airspace
     let first = &spaces[0];
-    assert_eq!(first.name, "FIRST AIRSPACE");
+    assert_eq!(first.name.as_deref(), Some("FIRST AIRSPACE"));
     assert_eq!(first.class, Class::D);
     assert_eq!(first.lower_bound, Altitude::Gnd);
     assert_eq!(first.upper_bound, Altitude::FeetAmsl(5000));
 
     // Check second airspace
     let second = &spaces[1];
-    assert_eq!(second.name, "SECOND AIRSPACE");
+    assert_eq!(second.name.as_deref(), Some("SECOND AIRSPACE"));
     assert_eq!(second.class, Class::Restricted);
     assert_eq!(second.lower_bound, Altitude::FeetAmsl(1000));
     assert_eq!(second.upper_bound, Altitude::FlightLevel(100));

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -6,7 +6,7 @@ use openair::*;
 #[test]
 fn serialize_json() {
     let airspace = Airspace {
-        name: "SUPERSPACE".into(),
+        name: Some("SUPERSPACE".into()),
         class: Class::Prohibited,
         lower_bound: Altitude::Gnd,
         upper_bound: Altitude::FeetAgl(3000),
@@ -45,7 +45,7 @@ fn serialize_json() {
 #[test]
 fn serialize_json_ctr() {
     let airspace = Airspace {
-        name: "Control Zone".into(),
+        name: Some("Control Zone".into()),
         class: Class::Ctr,
         lower_bound: Altitude::Gnd,
         upper_bound: Altitude::FeetAgl(1000),

--- a/tests/snapshots/parser__france_fixture-2.snap
+++ b/tests/snapshots/parser__france_fixture-2.snap
@@ -3,7 +3,9 @@ source: tests/parser.rs
 expression: spaces.last().unwrap()
 ---
 Airspace {
-    name: "LF-R17 E1 TEMPO ECKMUHL",
+    name: Some(
+        "LF-R17 E1 TEMPO ECKMUHL",
+    ),
     class: Unclassified,
     type_: Some(
         "R",

--- a/tests/snapshots/parser__france_fixture.snap
+++ b/tests/snapshots/parser__france_fixture.snap
@@ -3,7 +3,9 @@ source: tests/parser.rs
 expression: spaces.first().unwrap()
 ---
 Airspace {
-    name: "ZSM GYPAETE BARBU NID FELCE 2025",
+    name: Some(
+        "ZSM GYPAETE BARBU NID FELCE 2025",
+    ),
     class: Unclassified,
     type_: Some(
         "OFR",

--- a/tests/snapshots/parser__germany_border_fixture.snap
+++ b/tests/snapshots/parser__germany_border_fixture.snap
@@ -3,7 +3,9 @@ source: tests/parser.rs
 expression: spaces.first().unwrap()
 ---
 Airspace {
-    name: "FIR Bremen 125.100",
+    name: Some(
+        "FIR Bremen 125.100",
+    ),
     class: C,
     type_: None,
     lower_bound: FlightLevel(

--- a/tests/snapshots/parser__germany_fixture.snap
+++ b/tests/snapshots/parser__germany_fixture.snap
@@ -3,7 +3,9 @@ source: tests/parser.rs
 expression: spaces.first().unwrap()
 ---
 Airspace {
-    name: "ED-R LINDENBERG",
+    name: Some(
+        "ED-R LINDENBERG",
+    ),
     class: Restricted,
     type_: None,
     lower_bound: Gnd,

--- a/tests/snapshots/parser__switzerland_fixture.snap
+++ b/tests/snapshots/parser__switzerland_fixture.snap
@@ -3,7 +3,9 @@ source: tests/parser.rs
 expression: spaces.first().unwrap()
 ---
 Airspace {
-    name: "ALPNACH CTR 128.475",
+    name: Some(
+        "ALPNACH CTR 128.475",
+    ),
     class: D,
     type_: None,
     lower_bound: Gnd,

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -3,7 +3,7 @@ use openair::{Airspace, Altitude, Class, Coord, Geometry, PolygonSegment};
 #[test]
 fn write_single_airspace() {
     let airspace = Airspace {
-        name: "Test Zone".to_string(),
+        name: Some("Test Zone".to_string()),
         class: Class::D,
         type_: None,
         lower_bound: Altitude::Gnd,
@@ -38,7 +38,7 @@ fn write_single_airspace() {
 #[test]
 fn write_multiple_airspaces() {
     let airspace1 = Airspace {
-        name: "Zone A".to_string(),
+        name: Some("Zone A".to_string()),
         class: Class::A,
         type_: None,
         lower_bound: Altitude::Gnd,
@@ -57,7 +57,7 @@ fn write_multiple_airspaces() {
     };
 
     let airspace2 = Airspace {
-        name: "Zone B".to_string(),
+        name: Some("Zone B".to_string()),
         class: Class::B,
         type_: None,
         lower_bound: Altitude::FeetAmsl(1000),
@@ -85,7 +85,7 @@ fn write_multiple_airspaces() {
     };
 
     let airspace3 = Airspace {
-        name: "Zone C".to_string(),
+        name: Some("Zone C".to_string()),
         class: Class::C,
         type_: Some("CTR".to_string()),
         lower_bound: Altitude::Gnd,
@@ -149,7 +149,7 @@ fn write_empty_iterator() {
 #[test]
 fn write_with_vec() {
     let airspace = Airspace {
-        name: "Test".to_string(),
+        name: Some("Test".to_string()),
         class: Class::D,
         type_: None,
         lower_bound: Altitude::Gnd,


### PR DESCRIPTION
The OpenAir spec only requires AC to start an airspace; AN is optional. Real-world files (e.g. German airspace data) contain airspaces without AN records, causing the parser to fail with "Missing name".

Change `name` from `String` to `Option<String>` so these files parse successfully.

Closes #47