### PR TITLE
Replace dead WinPilot link with Naviter format specification

### DIFF
--- a/FORMAT.txt
+++ b/FORMAT.txt
@@ -4,6 +4,9 @@
 *    Updated October 15, 1999
 *    Send comments to jerryp@winpilot.com
 *
+*    For a more up-to-date specification, see:
+*    https://github.com/naviter/seeyou_file_formats/blob/main/OpenAir_File_Format_Support.md
+*
 *
 *  AIRSPACE related record types:
 *  ==============================

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A Rust library for reading and writing airspace files in OpenAir format (used by flight instruments
 like Skytraxx and others).
 
-http://www.winpilot.com/UsersGuide/UserAirspace.asp (see also `FORMAT.txt`)
+https://github.com/naviter/seeyou_file_formats/blob/main/OpenAir_File_Format_Support.md (see also `FORMAT.txt`)
 
 Docs: https://docs.rs/openair/
 


### PR DESCRIPTION
The original WinPilot URL is no longer reachable. Point to the more up-to-date Naviter specification instead.

Closes #45